### PR TITLE
feat: osm access hierarchy for bicycles

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,6 +48,7 @@ Here is an overview:
  * jessLryan, max elevation can now be negative
  * joe-akeem, improvements like #2158
  * JohannesPelzer, improved GPX information and various other things
+ * karololszacki, way access hierarchy for bicycles (esp. ferries)
  * karussell, one of the core developers
  * khuebner, initial turn costs support
  * kodonnell, adding support for CH and other algorithms (#60) and penalizing inner-link U-turns (#88)

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
@@ -107,7 +107,7 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
             // `;` can be an access delimiter; https://github.com/graphhopper/graphhopper/pull/2676
             String[] split = value.split(";");
             for (String val : split) {
-                if (restrictedValues.contains(val)) {
+                if (restrictedValues.contains(val) && !hasTemporalRestriction(way, restrictionKeys.indexOf(key), restrictionKeys)) {
                     return WayAccess.CAN_SKIP; // explicit ban!
                 }
                 if (intendedValues.contains(val)) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
@@ -78,6 +78,13 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
     }
 
     private WayAccess checkNonHighwayAccess(ReaderWay way) {
+        // special case not for all acceptedRailways, only platform
+        if (way.hasTag("railway", "platform"))
+            return WayAccess.WAY;
+
+        if (way.hasTag("man_made", "pier"))
+            return WayAccess.WAY;
+
         WayAccess access = WayAccess.CAN_SKIP;
 
         if (FerrySpeedCalculator.isFerry(way)) {
@@ -86,13 +93,6 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
             if (bikeTag == null && !way.hasTag("foot") || intendedValues.contains(bikeTag))
                 access = WayAccess.FERRY;
         }
-
-        // special case not for all acceptedRailways, only platform
-        if (way.hasTag("railway", "platform"))
-            access = WayAccess.WAY;
-
-        if (way.hasTag("man_made", "pier"))
-            access = WayAccess.WAY;
 
         if (!access.canSkip()) {
             if (way.hasTag(restrictionKeys, restrictedValues))

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
@@ -42,29 +42,7 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
     public WayAccess getAccess(ReaderWay way) {
         String highwayValue = way.getTag("highway");
         if (highwayValue == null) {
-            WayAccess access = WayAccess.CAN_SKIP;
-
-            if (FerrySpeedCalculator.isFerry(way)) {
-                // if bike is NOT explicitly tagged allow bike but only if foot is not specified either
-                String bikeTag = way.getTag("bicycle");
-                if (bikeTag == null && !way.hasTag("foot") || intendedValues.contains(bikeTag))
-                    access = WayAccess.FERRY;
-            }
-
-            // special case not for all acceptedRailways, only platform
-            if (way.hasTag("railway", "platform"))
-                access = WayAccess.WAY;
-
-            if (way.hasTag("man_made", "pier"))
-                access = WayAccess.WAY;
-
-            if (!access.canSkip()) {
-                if (way.hasTag(restrictionKeys, restrictedValues))
-                    return WayAccess.CAN_SKIP;
-                return access;
-            }
-
-            return WayAccess.CAN_SKIP;
+            return checkNonHighwayAccess(way);
         }
 
         if (!allowedHighways.contains(highwayValue))
@@ -98,6 +76,33 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
 
         return WayAccess.WAY;
     }
+
+    private WayAccess checkNonHighwayAccess(ReaderWay way) {
+        WayAccess access = WayAccess.CAN_SKIP;
+
+        if (FerrySpeedCalculator.isFerry(way)) {
+            // if bike is NOT explicitly tagged allow bike but only if foot is not specified either
+            String bikeTag = way.getTag("bicycle");
+            if (bikeTag == null && !way.hasTag("foot") || intendedValues.contains(bikeTag))
+                access = WayAccess.FERRY;
+        }
+
+        // special case not for all acceptedRailways, only platform
+        if (way.hasTag("railway", "platform"))
+            access = WayAccess.WAY;
+
+        if (way.hasTag("man_made", "pier"))
+            access = WayAccess.WAY;
+
+        if (!access.canSkip()) {
+            if (way.hasTag(restrictionKeys, restrictedValues))
+                return WayAccess.CAN_SKIP;
+            return access;
+        }
+
+        return WayAccess.CAN_SKIP;
+    }
+
 
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
@@ -379,7 +379,7 @@ public abstract class AbstractBikeTagParserTester {
         way.setTag("highway", "path");
         assertTrue(accessParser.getAccess(way).isWay());
         way.setTag("vehicle", "no");
-        assertTrue(accessParser.getAccess(way).isWay());
+        assertTrue(accessParser.getAccess(way).canSkip()); // TODO: discuss whether pushing should be allowed and how
         way.setTag("bicycle", "no");
         assertTrue(accessParser.getAccess(way).canSkip());
 
@@ -444,7 +444,7 @@ public abstract class AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "secondary");
         way.setTag("vehicle", "no");
-        assertTrue(accessParser.getAccess(way).isWay());
+        assertTrue(accessParser.getAccess(way).canSkip()); // TODO: bicycle is a vehicle! should we add special value for "dismount" & pushing?
         way.setTag("bicycle", "dismount");
         assertTrue(accessParser.getAccess(way).isWay());
         way.setTag("bicycle", "no");
@@ -474,7 +474,7 @@ public abstract class AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "track");
         way.setTag("vehicle", "forestry");
-        assertTrue(accessParser.getAccess(way).isWay());
+        assertTrue(accessParser.getAccess(way).canSkip());
         way.setTag("bicycle", "yes");
         assertTrue(accessParser.getAccess(way).isWay());
     }
@@ -710,14 +710,14 @@ public abstract class AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("route", "ferry");
         way.setTag("foot", "yes");
-        assertFalse(accessParser.getAccess(way).isFerry());
+        assertTrue(accessParser.getAccess(way).isFerry()); // TODO: nothing is said for bicycles, should they be allowed to carry?
 
-        // #1122
+        // #1122 - discuss?
         way.clearTags();
         way.setTag("route", "ferry");
         way.setTag("bicycle", "yes");
         way.setTag("access", "private");
-        assertTrue(accessParser.getAccess(way).canSkip());
+        assertTrue(accessParser.getAccess(way).isFerry()); // TODO: "bicycle" should trump access here, right?
 
         // #1562, test if ferry route with bicycle
         way.clearTags();
@@ -739,13 +739,14 @@ public abstract class AbstractBikeTagParserTester {
 
         way.setTag("bicycle", "designated");
         way.setTag("access", "private");
-        assertTrue(accessParser.getAccess(way).canSkip());
+        assertTrue(accessParser.getAccess(way).isFerry()); // TODO: same issue as #1122, bicycle should trump access
 
         // test if when foot is set is invalid
-        way.clearTags();
-        way.setTag("route", "ferry");
-        way.setTag("foot", "yes");
-        assertTrue(accessParser.getAccess(way).canSkip());
+        // way.clearTags();
+        // way.setTag("route", "ferry");
+        // way.setTag("foot", "yes");
+        // assertTrue(accessParser.getAccess(way).canSkip());
+        // ^TODO: duplicate - tags were cleared, this assert is exactly the same as the second block in this test-method
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -446,7 +446,7 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "cycleway");
         way.setTag("vehicle", "no");
-        assertTrue(accessParser.getAccess(way).isWay());
+        assertTrue(accessParser.getAccess(way).canSkip());
 
         // Senseless tagging: JOSM does create a warning here:
         way.setTag("bicycle", "no");
@@ -481,12 +481,13 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("bicycle", "yes");
         assertTrue(accessParser.getAccess(way).isWay());
 
+        // forestry is supposed to be skipped; originates in https://github.com/graphhopper/graphhopper/pull/2676
         way.clearTags();
         way.setTag("highway", "track");
         way.setTag("vehicle", "forestry");
-        assertTrue(accessParser.getAccess(way).isWay());
+        assertTrue(accessParser.getAccess(way).canSkip());
         way.setTag("vehicle", "agricultural;forestry");
-        assertTrue(accessParser.getAccess(way).isWay());
+        assertTrue(accessParser.getAccess(way).canSkip());
     }
 
     @Test


### PR DESCRIPTION
Hi, in this PR I am trying to align bicycle access parser more with the OSM Access hierarchy.
Most lines changed are actually in (added) tests :)

## Issues I identified on the current master:
a) Sometime in the recent past, `vehicles` were removed from `restrictionKeys` to "allow for walking via dismount" on some paths - I believe such cases should be solved **in some other way**. One solution could be to utilize the `WayAccess.OTHER` value (also for explicit `dismount` tagging), another: introducing new values like `WayAccess.SPECIAL` or `WayAccess.DISMOUNT`. I did not introduce any solutions for "allow for walking via dismount" here yet.
b) At similar time as the above change happened, the `vehicle=forrestry` ban that was introduced in https://github.com/graphhopper/graphhopper/pull/2676 got broken (and test got changed), I restored the previous test (and with the new logic it is now passing again)
c) Ferry ways tagged `access=private` should be ignored, but if it's accompanied by eg. `bicycle=yes` then such tagging should trump the less specific one (and way should be allowed for bicycle). This stems from issue https://github.com/graphhopper/graphhopper/issues/1122 and I believe should be re-discussed, or at least tests following it (added in PR https://github.com/graphhopper/graphhopper/pull/1124).

## What I did in this PR:
1. [commits 1,2] I added more tests for the scenarios I mentioned above
2. [commits 3,4] I extracted method `checkNonHighwayAccess` to re-use the checks there
3. [commit 5] I added method `checkExplicitRestrictionsHierarchy` that further simplifies part of `checkNonHighwayAccess` and makes it more universal
4. [commit 6] I re-added original restrictionKeys from `OSMRoadAccessParser.toOSMRestrictions` to bicycle access parser and used just added `checkExplicitRestrictionsHierarchy` 
5. [commit 8] I adjusted current tests (please check comments that I left)

## Summary

I restored "full" bicycle hierarchy of OSM for ways, that is if `vehicles` are allowed - bikes should be allowed, and if they are not, then bikes also aren't. This is especially important for ferry links (which usually have little other tags).
There is still "undefined behavior" in the OSM wiki for eg. ferries that have no explicit bicycle tagging. The new method `checkExplicitRestrictionsHierarchy` will currently return (otherwise unused) `WayAccess.OTHER`. 

OSM access hierarchy reference: https://wiki.openstreetmap.org/wiki/Key:access#Land-based_transportation

---

✅ Please read [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) and note that also your contribution falls under the Apache License 2.0 as outlined there.

✅ Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
